### PR TITLE
Improve sticky state tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "stickystate",
+  "version": "1.0.0",
+  "description": "",
+  "main": "stickystate.js",
+  "type": "commonjs",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom"
+  }
+}

--- a/stickystate.js
+++ b/stickystate.js
@@ -66,4 +66,11 @@
       observer.observe(sentinel);
     });
   }
+
+  // Expose setupStickyState for use in modules and tests
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = setupStickyState;
+  } else {
+    window.setupStickyState = setupStickyState;
+  }
 })();

--- a/stickystate.test.js
+++ b/stickystate.test.js
@@ -1,0 +1,48 @@
+const setupStickyState = require('./stickystate.js');
+
+let mockCallback;
+let observedElement;
+
+beforeEach(() => {
+  mockCallback = undefined;
+  observedElement = undefined;
+  document.body.innerHTML = '<div id="wrapper"><div id="elem" class="sticky"></div></div>';
+  global.IntersectionObserver = class {
+    constructor(cb, options) {
+      mockCallback = cb;
+    }
+    observe(el) {
+      observedElement = el;
+    }
+    disconnect() {}
+  };
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  delete global.IntersectionObserver;
+});
+
+test('inserts a sentinel before sticky element', () => {
+  setupStickyState();
+  const wrapper = document.getElementById('wrapper');
+  const sentinel = wrapper.firstChild;
+  const sticky = document.getElementById('elem');
+
+  expect(sentinel).not.toBeNull();
+  expect(sentinel.className).toBe('sticky-sentinel');
+  expect(observedElement).toBe(sentinel);
+  expect(sentinel.dataset.stickyId).toBe(sticky.dataset.stickyId);
+});
+
+test('toggles is-stuck class based on intersection', () => {
+  setupStickyState();
+  const sentinel = observedElement;
+  const sticky = document.getElementById('elem');
+
+  mockCallback([{ target: sentinel, isIntersecting: false }]);
+  expect(sticky.classList.contains('is-stuck')).toBe(true);
+
+  mockCallback([{ target: sentinel, isIntersecting: true }]);
+  expect(sticky.classList.contains('is-stuck')).toBe(false);
+});


### PR DESCRIPTION
## Summary
- configure Jest to use jsdom environment
- clean up DOM and observer between tests

## Testing
- `npm test` *(fails: jest not found)*